### PR TITLE
Support format keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Adds support for `format` in controller tests
+
 ## [2.2.0] - 2018-06-03
 
 - Adds support for `flash` and `session` in controller tests

--- a/gemfiles/actionpack_4.2.gemfile.lock
+++ b/gemfiles/actionpack_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails-forward_compatible_controller_tests (2.0.1)
+    rails-forward_compatible_controller_tests (2.2.0)
       actionpack (>= 4.2, < 5.1)
 
 GEM
@@ -77,4 +77,4 @@ DEPENDENCIES
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/gemfiles/actionpack_5.0.gemfile.lock
+++ b/gemfiles/actionpack_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails-forward_compatible_controller_tests (2.0.1)
+    rails-forward_compatible_controller_tests (2.2.0)
       actionpack (>= 4.2, < 5.1)
 
 GEM
@@ -76,4 +76,4 @@ DEPENDENCIES
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/lib/rails/forward_compatible_controller_tests.rb
+++ b/lib/rails/forward_compatible_controller_tests.rb
@@ -50,11 +50,13 @@ module Rails
         request_session = args[1]&.dup if controller_test
         request_headers = args[1]&.dup unless controller_test
         request_flash = args[2]&.dup if controller_test
+        request_format = nil
 
         old_method = false
         xhr = false
         if request_params && request_params.is_a?(Hash)
           xhr = request_params.delete(:xhr)
+          request_format = request_params.delete(:format)
           if request_params[:params].is_a?(Hash)
             request_params.merge!(request_params.delete(:params) || {})
             request_session = request_params.delete(:session) || request_session if controller_test
@@ -80,7 +82,7 @@ module Rails
             request_session = nil
             request_headers = nil
             request_params = nil
-          elsif !xhr
+          elsif !xhr && !request_format
             old_method = true
           end
         elsif request_headers.is_a?(Hash) || request_session.is_a?(Hash) ||
@@ -90,6 +92,8 @@ module Rails
 
         raise Exception, ERROR_MESSAGE if ForwardCompatibleControllerTests.raise_exception? && old_method
         ActiveSupport::Deprecation.warn(ERROR_MESSAGE) if ForwardCompatibleControllerTests.deprecated? && old_method
+
+        request_params[:format] = request_format if request_format
 
         if xhr
           ForwardCompatibleControllerTests.send(:with_ignore) do

--- a/test/controllers/kwargs_test.rb
+++ b/test/controllers/kwargs_test.rb
@@ -25,6 +25,11 @@ class KwargsControllerTest < test_class
       refute assigns(:xhr)
     end
 
+    define_method("test_#{verb}_old_params_only__allows_format_keyword") do
+      send(verb.to_sym, :test_kwargs, format: :json)
+      assert_equal({ 'format' => 'json' }, assigns(:params))
+    end
+
     define_method("test_#{verb}_old_params_only__outputs_deprecation") do
       Rails::ForwardCompatibleControllerTests.deprecate
 


### PR DESCRIPTION
Verified it works both when passed as a keyword argument, and as a parameter inside of params.